### PR TITLE
Evaluate description string

### DIFF
--- a/__init__.r
+++ b/__init__.r
@@ -18,7 +18,8 @@ description = function () {
     if (! grepl('^\\[1\\] ".*"$', .script_output[[1]]))
         return(NULL)
 
-    sub('^\\[1\\] "(.*)"$', '\\1', .script_output[[1]])
+    eval(parse(text = sub('^\\[1\\] ', '', .script_output[[1]])),
+         envir = new.env(parent = emptyenv()))
 }
 
 # The environment that is calling `import(sys)`

--- a/calc.r
+++ b/calc.r
@@ -2,7 +2,14 @@
 
 sys = modules::import('sys')
 
-"A simple mathematical expression evaluator"
+"
+🔢  A simple mathematical expression evaluator 📐
+
+Its features
+
+1. evaluation of raw R expressions via `eval`
+2. print overly verbose descriptions
+"
 VERSION = '1.0'
 
 sys$run({


### PR DESCRIPTION
Parsing the unevaluated command line string leads to escape characters
being displayed as an escape sequence, e.g. line break is displayed as
“\n”. See #19.

In addition, `strwrap` destroys formatting that might be contained in the description; consider the following Markdown-like formatting:

```
This program provides:

1. great fun
2. the best words
```

`sys` will subsequently format this as

```
This program provides:

1. great fun 2. the best words (version 1.x)
```

Clearly, `strwrap` should be replaced by something that parses something Markdown-like (but should be more lightweight). Furthermore, a line break should be introduced before the version number if the description is longer than one line.
